### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -134,6 +134,9 @@ def convert_document(input_path, output_path, advanced=False, options=None):
 
 def fallback_convert(input_path, output_path, advanced=False, options=None):
     try:
+        output_path = os.path.normpath(output_path)
+        if not output_path.startswith(app.config['CONVERTED_FOLDER']):
+            raise Exception("Invalid output path")
         shutil.copy(input_path, output_path)
         logger.info(f"Fallback conversion: file copied to {output_path}")
         return True, "File copied without conversion (unsupported file type)"
@@ -142,6 +145,9 @@ def fallback_convert(input_path, output_path, advanced=False, options=None):
         return False, str(e)
 
 def convert_file(input_path, output_path, compress=False, advanced=False, options=None):
+    output_path = os.path.normpath(output_path)
+    if not output_path.startswith(app.config['CONVERTED_FOLDER']):
+        raise Exception("Invalid output path")
     ext = os.path.splitext(input_path)[1].lower()
     if ext in ['.png', '.jpg', '.jpeg', '.bmp', '.gif', '.tiff']:
         return convert_image(input_path, output_path, compress=compress, advanced=advanced, options=options)


### PR DESCRIPTION
Potential fix for [https://github.com/KernFerm/Bubbles-Cloud-Converter/security/code-scanning/12](https://github.com/KernFerm/Bubbles-Cloud-Converter/security/code-scanning/12)

To fix the problem, we need to ensure that the constructed `output_path` is validated before being used in file operations. We can achieve this by normalizing the path and ensuring it is contained within a safe root directory. This involves:
1. Normalizing the `output_path` using `os.path.normpath`.
2. Ensuring the normalized path starts with the intended root directory (`app.config['CONVERTED_FOLDER']`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
